### PR TITLE
sepolicy: Resolve offline charger sepolicy denials [1/2]

### DIFF
--- a/rootdir/init.qcom.rc
+++ b/rootdir/init.qcom.rc
@@ -347,6 +347,8 @@ service thermanager /vendor/bin/thermanager /system/etc/thermanager.xml
 # Offline charger
 service charger /charger
     class charger
+    user root
+    group root radio system
     seclabel u:r:charger:s0
 
 on property:ro.boot.baseband=mdm

--- a/sepolicy/charger.te
+++ b/sepolicy/charger.te
@@ -1,0 +1,2 @@
+#============= charger ==============
+allow charger sysfs_leds:file write;


### PR DESCRIPTION
* Set default root user and group
 * Add charger to 'radio' group to access /dev/alarm
 * Allow charger to write in sysfs_leds
 * Open /dev/alarm as read-only to avoid dac_override